### PR TITLE
Added DB_PORT to vars template

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ docker run -d \
   -e PGID=1000 \
   -e TZ=Europe/London \
   -e DB_HOST=mariadb \
+  -e DB_PORT=3306 \
   -e DB_USERNAME=lychee \
   -e DB_PASSWORD=dbpassword \
   -e DB_DATABASE=lychee \
@@ -145,6 +146,7 @@ Container images are configured using parameters passed at runtime (such as thos
 | `-e PGID=1000` | for GroupID - see below for explanation |
 | `-e TZ=Europe/London` | Specify a timezone to use EG Europe/London |
 | `-e DB_HOST=mariadb` | for specifying the database host |
+| `-e DB_PORT=3306` | for specifying the database port |
 | `-e DB_USERNAME=lychee` | for specifying the database user |
 | `-e DB_PASSWORD=dbpassword` | for specifying the database password |
 | `-e DB_DATABASE=lychee` | for specifying the database to be used |

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -32,6 +32,7 @@ param_usage_include_env: true
 param_env_vars:
   - { env_var: "TZ", env_value: "Europe/London", desc: "Specify a timezone to use EG Europe/London"}
   - { env_var: "DB_HOST", env_value: "mariadb", desc: "for specifying the database host" }
+  - { env_var: "DB_PORT", env_value: "3306", desc: "for specifying the database port" }
   - { env_var: "DB_USERNAME", env_value: "lychee", desc: "for specifying the database user" }
   - { env_var: "DB_PASSWORD", env_value: "dbpassword", desc: "for specifying the database password" }
   - { env_var: "DB_DATABASE", env_value: "lychee", desc: "for specifying the database to be used" }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]


<!--- Before submitting a pull request please check the following -->

<!---  If this is a fix for a typo (in code, documentation, or the README) please file an issue and let us sort it out. We do not need a PR  -->
<!---  Ask yourself if this modification is something the whole userbase will benefit from, if this is a specific change for corner case functionality or plugins please look at making a Docker Mod or local script  https://blog.linuxserver.io/2019/09/14/customizing-our-containers/ -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!--- We maintain a changelog of major revisions to the container at the end of readme-vars.yml in the root of this repository, please add your changes there if appropriate -->


<!--- Coding guidelines: -->
<!--- 1. Installed packages in the Dockerfiles should be in alphabetical order -->
<!--- 2. Changes to Dockerfile should be replicated in Dockerfile.armhf and Dockerfile.aarch64 if applicable -->
<!--- 3. Indentation style (tabs vs 4 spaces vs 1 space) should match the rest of the document -->
<!--- 4. Readme is auto generated from readme-vars.yml, make your changes there -->

------------------------------

 - [x] I have read the [contributing](https://github.com/linuxserver/docker-lychee/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

<!--- We welcome all PR’s though this doesn’t guarantee it will be accepted. -->

## Description:
<!--- Describe your changes in detail -->
Since this check was added to the startup script:
```
        until nc -z -v -w30 "${DB_HOST}" "${DB_PORT}"
        do
            echo "Waiting for database connection..."
            # wait for 5 seconds before check again
            sleep 5
        done
```
DB_PORT is no longer optional. I've added it to the readme_vars so that the correct [unraid template](https://github.com/linuxserver/templates/blob/main/unraid/lychee.xml) will get generated (and the readme is updated of course :smile:). I spent far too long trying to fix my database! :laughing:.

## Benefits of this PR and context:
<!--- Please explain why we should accept this PR. If this fixes an outstanding bug, please reference the issue # -->
Closes #59 ?

## How Has This Been Tested?
I ran the jenkins-builder and the changes to README.md look good?

I don't know how to prove that the unraid template is fixed..
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## Source / References:
<!--- Please include any forum posts/github links relevant to the PR -->
