### PR TITLE
Allowing video uploads of 500MB seems reasonable nowadays, rather than 20MB.

### DIFF
--- a/root/defaults/user.ini
+++ b/root/defaults/user.ini
@@ -2,7 +2,7 @@
 ; Note that with FastCGI, you might also want to set FcgidBusyTimeout, FcgidIOTimeout and FcgidMaxRequestLen in your Apache config
 
 max_execution_time = 200
-post_max_size = 200M
-upload_max_size = 200M
-upload_max_filesize = 20M
+post_max_size = 500M
+upload_max_size = 500M
+upload_max_filesize = 500M
 max_file_uploads = 200


### PR DESCRIPTION
Dear Maintainers,

I am writing to submit a pull request to increase the video upload limit from 20MB to 500MB for Lychee, which I am using as a Docker container from linuxserver.io. The current limit is insufficient for uploading larger video files, and I believe that raising the limit to 500MB would greatly benefit the userbase.

Here are the details of my pull request:

Description:
I propose increasing the video upload limit in the Lychee Docker container from 20MB to 500MB. This change will provide users with the ability to upload larger video files, accommodating their needs in today's multimedia-rich environment.

Benefits of this PR and context:
By raising the upload limit to 500MB, users will have greater flexibility and convenience when uploading videos to Lychee. It will enhance the overall user experience and enable them to seamlessly share high-quality video content.

How Has This Been Tested?
I have thoroughly tested this modification in my own testing environment. I have successfully uploaded various video files exceeding 20MB in size, up to 500MB, and verified that the upload process functions correctly without any issues.

Source / References:
No specific source or references are relevant to this pull request.

I have read and understood the contributing guidelines provided [here](https://github.com/linuxserver/docker-lychee/blob/master/.github/CONTRIBUTING.md) and ensured that my modifications align with them.

Thank you for considering my pull request. I believe that increasing the video upload limit will greatly improve the functionality of Lychee and benefit its userbase.

Sincerely,
[ZarTek-Creole](https://github.com/ZarTek-Creole)