### PR TITLE
Update README: Guidance for Customizing Upload Limits

### DIFF
--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -91,7 +91,7 @@ app_setup_block: |
 
   In certain scenarios, you might need to change the default settings of Lychee. For instance, if you encounter limitations when uploading large files, you can increase this limit.
 
-  ### Increasing Upload Limit
+  #### Increasing Upload Limit
 
   The upload limit is defined in the `user.ini` file located in the config directory (`/config`). You can increase this limit by modifying the following values:
 

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -102,18 +102,6 @@ app_setup_block: |
 
   After making these changes, you'll need to restart the Docker container for the changes to take effect. Here's how to do it:
 
-  #### Via Docker Compose
-
-  ```bash
-  docker-compose restart lychee
-  ```
-
-  #### Via Docker Run
-
-  ```bash
-  docker restart lychee
-  ```
-
   **Please note that these changes might have implications on your server's performance, depending on its available resources. Thus, it's recommended to modify these settings with caution.**
 
 # changelog

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -114,7 +114,7 @@ app_setup_block: |
   docker restart lychee
   ```
 
-  ⚠️ Please note that these changes might have implications on your server's performance, depending on its available resources. Thus, it's recommended to modify these settings with caution.
+  **Please note that these changes might have implications on your server's performance, depending on its available resources. Thus, it's recommended to modify these settings with caution.**
 
 # changelog
 changelogs:

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -108,7 +108,7 @@ app_setup_block: |
   docker-compose restart lychee
   ```
 
-  #### 🔁 Via Docker Run
+  #### Via Docker Run
 
   ```bash
   docker restart lychee

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -87,7 +87,7 @@ app_setup_block: |
   Setup mysql/mariadb and account via the webui, accessible at http://SERVERIP:PORT
   More info at [lychee]({{ project_url }}).
 
-  ## Customization
+  ### Customization
 
   In certain scenarios, you might need to change the default settings of Lychee. For instance, if you encounter limitations when uploading large files, you can increase this limit.
 

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -87,6 +87,35 @@ app_setup_block: |
   Setup mysql/mariadb and account via the webui, accessible at http://SERVERIP:PORT
   More info at [lychee]({{ project_url }}).
 
+  ## 🛠️ Customization
+
+  In certain scenarios, you might need to change the default settings of Lychee. For instance, if you encounter limitations when uploading large files, you can increase this limit. 📈
+
+  ### 📤 Increasing Upload Limit
+
+  The upload limit is defined in the `user.ini` file located in the config directory (`/config`). You can increase this limit by modifying the following values:
+
+  ```ini
+  post_max_size = 500M
+  upload_max_filesize = 500M
+  ```
+
+  After making these changes, you'll need to restart the Docker container for the changes to take effect. Here's how to do it:
+
+  #### 🔁 Via Docker Compose
+
+  ```bash
+  docker-compose restart lychee
+  ```
+
+  #### 🔁 Via Docker Run
+
+  ```bash
+  docker restart lychee
+  ```
+
+  ⚠️ Please note that these changes might have implications on your server's performance, depending on its available resources. Thus, it's recommended to modify these settings with caution.
+
 # changelog
 changelogs:
   - { date: "13.04.23:", desc: "Move ssl.conf include to default.conf." }

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -87,7 +87,7 @@ app_setup_block: |
   Setup mysql/mariadb and account via the webui, accessible at http://SERVERIP:PORT
   More info at [lychee]({{ project_url }}).
 
-  ## 🛠️ Customization
+  ## Customization
 
   In certain scenarios, you might need to change the default settings of Lychee. For instance, if you encounter limitations when uploading large files, you can increase this limit. 📈
 

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -89,7 +89,7 @@ app_setup_block: |
 
   ## Customization
 
-  In certain scenarios, you might need to change the default settings of Lychee. For instance, if you encounter limitations when uploading large files, you can increase this limit. 📈
+  In certain scenarios, you might need to change the default settings of Lychee. For instance, if you encounter limitations when uploading large files, you can increase this limit.
 
   ### 📤 Increasing Upload Limit
 

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -102,7 +102,7 @@ app_setup_block: |
 
   After making these changes, you'll need to restart the Docker container for the changes to take effect. Here's how to do it:
 
-  #### 🔁 Via Docker Compose
+  #### Via Docker Compose
 
   ```bash
   docker-compose restart lychee

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -91,7 +91,7 @@ app_setup_block: |
 
   In certain scenarios, you might need to change the default settings of Lychee. For instance, if you encounter limitations when uploading large files, you can increase this limit.
 
-  ### 📤 Increasing Upload Limit
+  ### Increasing Upload Limit
 
   The upload limit is defined in the `user.ini` file located in the config directory (`/config`). You can increase this limit by modifying the following values:
 


### PR DESCRIPTION
This commit adds a new section to the README.md file to provide users with guidance on how to customize upload limits in Lychee Docker container. This update is a follow-up to pull request https://github.com/linuxserver/docker-lychee/pull/64, where it was suggested that instead of changing default settings, it would be more beneficial to provide clear instructions to users on how to make this change themselves. 

The new section includes step-by-step instructions on modifying the `user.ini` file, as well as the necessary commands to restart the Docker container for the changes to take effect. It also adds a note of caution, reminding users that changing these settings may impact their server's performance.
