### PR TITLE
Cleanup default site conf

### DIFF
--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -107,6 +107,7 @@ app_setup_block: |
 
 # changelog
 changelogs:
+  - { date: "25.12.23:", desc: "Existing users should update: site-confs/default.conf - Cleanup default site conf." }
   - { date: "25.05.23:", desc: "Rebase to Alpine 3.18, deprecate armhf." }
   - { date: "13.04.23:", desc: "Move ssl.conf include to default.conf." }
   - { date: "11.01.23:", desc: "Rebasing to alpine 3.17 with php8.1. Restructure nginx configs ([see changes announcement](https://info.linuxserver.io/issues/2022-08-20-nginx-base)). Switch to git clone as builds fail with the release artifact." }

--- a/root/defaults/nginx/site-confs/default.conf.sample
+++ b/root/defaults/nginx/site-confs/default.conf.sample
@@ -1,4 +1,4 @@
-## Version 2023/04/13 - Changelog: https://github.com/linuxserver/docker-lychee/commits/master/root/defaults/nginx/site-confs/default.conf.sample
+## Version 2023/12/25 - Changelog: https://github.com/linuxserver/docker-lychee/commits/master/root/defaults/nginx/site-confs/default.conf.sample
 
 server {
     listen 80 default_server;
@@ -11,11 +11,7 @@ server {
 
     include /config/nginx/ssl.conf;
 
-    set $root /app/www/public;
-    if (!-d /app/www/public) {
-        set $root /config/www;
-    }
-    root $root;
+    root /app/www/public;
     index index.html index.htm index.php;
 
     location / {
@@ -23,17 +19,16 @@ server {
         #auth_basic "Restricted";
         #auth_basic_user_file /config/nginx/.htpasswd;
 
-        try_files $uri $uri/ /index.html /index.php$is_args$args;
-    }
-
-    # unless the request is for a valid file (image, js, css, etc.), send to bootstrap
-    if (!-e $request_filename) {
-        rewrite ^/(.*)$ /index.php?/$1 last;
-        break;
+        try_files $uri $uri/ /index.html /index.htm /index.php$is_args$args;
     }
 
     location ~ ^(.+\.php)(.*)$ {
+        # enable the next two lines for http auth
+        #auth_basic "Restricted";
+        #auth_basic_user_file /config/nginx/.htpasswd;
+
         fastcgi_split_path_info ^(.+\.php)(.*)$;
+        if (!-f $document_root$fastcgi_script_name) { return 404; }
         fastcgi_pass 127.0.0.1:9000;
         fastcgi_index index.php;
         include /etc/nginx/fastcgi_params;


### PR DESCRIPTION
This probably needs a bit of testing. The upstream docs do a handful of things https://www.nginx.com/resources/wiki/start/topics/tutorials/config_pitfalls/ and https://www.nginx.com/resources/wiki/start/topics/depth/ifisevil/ says not to do. It SHOULD work with this conf, but the url rewrite might behave differently.